### PR TITLE
Add External Function capability

### DIFF
--- a/Math expression eval/UnitTest/TestAll.cs
+++ b/Math expression eval/UnitTest/TestAll.cs
@@ -1170,19 +1170,19 @@ namespace UnitTest
                 .Bind("a", 0)
                 .Bind("b", 0);
             Assert.AreEqual(false, expr.Eval<bool>());
-
+            
             // false, true = true
             var expr2 = new Expression("OR (a>0, b>0)")
                 .Bind("a", 0)
                 .Bind("b", 1);
             Assert.AreEqual(true, expr2.Eval<bool>());
-
+            
             // true, false = true
             var expr3 = new Expression("OR (a>0, b>0)")
                 .Bind("a", 1)
                 .Bind("b", 0);
             Assert.AreEqual(true, expr3.Eval<bool>());
-
+            
             // true, true = true
             var expr4 = new Expression("OR (a>0, b>0)")
                 .Bind("a", 1)

--- a/Math expression eval/UnitTest/TestAll.cs
+++ b/Math expression eval/UnitTest/TestAll.cs
@@ -1222,7 +1222,7 @@ namespace UnitTest
         [DataTestMethod]
         [DataRow("RANGE(1,2)")]
         [DataRow("REPEAT(\"xx\",3)")]
-        public void External_Function_NoExternal_Test(string formula)
+        public void External_Function_NotSet_Test(string formula)
         {
             var expr = new Expression(formula);
             Assert.ThrowsException<Exception>(() => expr.Eval<object>());

--- a/Math expression eval/org.matheval/Expression.cs
+++ b/Math expression eval/org.matheval/Expression.cs
@@ -324,7 +324,7 @@ namespace org.matheval
                 decimal resultDec =  Afe_Common.Round(result, this.Dc);
                 if (resultDec < 0)
                 {
-                    // return resultDec;
+                   // return resultDec;
                 }
                 return resultDec;
             }
@@ -519,7 +519,7 @@ namespace org.matheval
                 throw new Exception(Afe_Common.MSG_IFELSE_WRONG_SYNTAX);
             }
             else if (root is SwitchCaseNode)
-            {
+            { 
                 return this.ExecuteSwitchCase((SwitchCaseNode)root);
             }
             else if (root is CallFuncNode)

--- a/Math expression eval/org.matheval/Expression.cs
+++ b/Math expression eval/org.matheval/Expression.cs
@@ -80,7 +80,7 @@ namespace org.matheval
         /// <param name="formular">Input fomular text or math expression string</param>
         public Expression(string formular)
         {
-            this.Dc = new ExpressionContext(6, MidpointRounding.ToEven, "yyyy-MM-dd", "yyyy-MM-dd HH:mm", @"hh\:mm", CultureInfo.InvariantCulture);
+            this.Dc = new ExpressionContext(6, MidpointRounding.ToEven,"yyyy-MM-dd", "yyyy-MM-dd HH:mm", @"hh\:mm", CultureInfo.InvariantCulture);
             this.VariableParams = new Dictionary<string, object>();
             this.Parser = new Parser(this.Dc, formular);
         }
@@ -252,7 +252,7 @@ namespace org.matheval
         /// <returns>Current instance</returns>
         public Expression DisableFunction(string functionName)
         {
-            if (functionName != null && !functionName.Trim().Equals(""))
+            if (functionName!=null && !functionName.Trim().Equals(""))
             {
                 if (this.NotAllowedFunctions == null)
                 {
@@ -321,7 +321,7 @@ namespace org.matheval
             Object result = this.VisitNode(Root);
             if (result is decimal)
             {
-                decimal resultDec = Afe_Common.Round(result, this.Dc);
+                decimal resultDec =  Afe_Common.Round(result, this.Dc);
                 if (resultDec < 0)
                 {
                     // return resultDec;
@@ -420,29 +420,22 @@ namespace org.matheval
         /// <param name="holder"></param>
         private void VisitVariableNode(Implements.Node root, List<String> holder)
         {
-            if (root is VariableNode)
-            {
+            if (root is VariableNode){
                 VariableNode varNode = (VariableNode)root;
                 if (!holder.Contains(varNode.Name))
                 {
                     holder.Add(varNode.Name);
                 }
-            }
-            else if (root is BinanyNode)
-            {
+            }else if (root is BinanyNode){
                 BinanyNode binNode = (BinanyNode)root;
                 VisitVariableNode(binNode.LHS, holder);
                 VisitVariableNode(binNode.RHS, holder);
-            }
-            else if (root is IfElseNode)
-            {
+            }else if (root is IfElseNode){
                 IfElseNode ifElseNode = (IfElseNode)root;
                 VisitVariableNode(ifElseNode.Condition, holder);
                 VisitVariableNode(ifElseNode.IfTrue, holder);
                 VisitVariableNode(ifElseNode.IfFalse, holder);
-            }
-            else if (root is SwitchCaseNode)
-            {
+            }else if (root is SwitchCaseNode){
                 SwitchCaseNode caseNode = (SwitchCaseNode)root;
                 VisitVariableNode(caseNode.conditionExpr, holder);
                 for (int i = 0; i < caseNode.varResultExprs.Count - 1; i = i + 1)
@@ -450,18 +443,14 @@ namespace org.matheval
                     VisitVariableNode(caseNode.varResultExprs[i], holder);
                 }
                 VisitVariableNode(caseNode.defaultExpr, holder);
-            }
-            else if (root is CallFuncNode)
-            {
+            }else if (root is CallFuncNode){
                 CallFuncNode callFunc = (CallFuncNode)root;
                 for (int i = 0; i < callFunc.args.Count; i++)
                 {
                     Implements.Node expr = callFunc.args[i];
                     VisitVariableNode(expr, holder);
                 }
-            }
-            else if (root is UnaryNode)
-            {
+            }else if (root is UnaryNode){
                 UnaryNode unaryNode = (UnaryNode)root;
                 VisitVariableNode(unaryNode.Expr, holder);
             }
@@ -483,7 +472,7 @@ namespace org.matheval
             else if (root is NumberNode)
             {
                 NumberNode numberNode = (NumberNode)root;
-                return numberNode.mustRoundFlag ? Afe_Common.Round(numberNode.NumberValue, this.Dc) : numberNode.NumberValue;
+                return numberNode.mustRoundFlag ? Afe_Common.Round(numberNode.NumberValue, this.Dc): numberNode.NumberValue;
             }
             else if (root is StringNode)
             {
@@ -571,7 +560,7 @@ namespace org.matheval
                 argsMap.Add(i.ToString(), VisitNode(expr));
             }
 
-            if (!callFunc.IsExternal)
+            if (callFunc.Excuter != null)
                 return callFunc.Excuter.Execute(argsMap, Dc);
 
             if (TryExternalFunction != null && TryExternalFunction(callFunc.FuncName, argsMap.Values.ToArray(), Dc, out Object result))
@@ -595,7 +584,7 @@ namespace org.matheval
                 bool compareResult = (bool)eq.Calculate(condition, var, this.Dc);
                 if (compareResult)
                 {
-                    return this.VisitNode(root.varResultExprs[i + 1]);
+                    return this.VisitNode(root.varResultExprs[i+1]);
                 }
             }
             return this.VisitNode(root.defaultExpr);

--- a/Math expression eval/org.matheval/Parser/Node/CallFuncNode.cs
+++ b/Math expression eval/org.matheval/Parser/Node/CallFuncNode.cs
@@ -10,6 +10,9 @@ namespace org.matheval.Node
     /// </summary>
     public class CallFuncNode : Implements.Node
     {
+        public static CallFuncNode ExternalFunction(string name, List<Implements.Node> args)
+            => new CallFuncNode(name, args, typeof(object), null, true);
+
         /// <summary>
         /// Function Name
         /// </summary>
@@ -26,6 +29,11 @@ namespace org.matheval.Node
         public List<Implements.Node> args;
 
         /// <summary>
+        /// Is this an external function?
+        /// </summary>
+        public bool IsExternal { get; }
+
+        /// <summary>
         /// Initializes a new instance structure to a specified
         /// 1. Function Name
         /// 2. List Value args
@@ -34,11 +42,18 @@ namespace org.matheval.Node
         /// <param name="funcName">funcName</param>
         /// <param name="args">args</param>
         /// <param name="returnType">returnType</param>
-        public CallFuncNode(string funcName, List<Implements.Node> args,Type returnType, IFunction excuter) : base(returnType)
+        public CallFuncNode(string funcName, List<Implements.Node> args, Type returnType, IFunction excuter)
+            : this(funcName, args, returnType, excuter, false)
+        {
+        }
+
+        private CallFuncNode(string funcName, List<Implements.Node> args, Type returnType, IFunction excuter, bool isExternal)
+            : base(returnType)
         {
             this.FuncName = funcName;
             this.args = args;
             this.Excuter = excuter;
+            IsExternal = isExternal;
         }
     }
 }

--- a/Math expression eval/org.matheval/Parser/Node/CallFuncNode.cs
+++ b/Math expression eval/org.matheval/Parser/Node/CallFuncNode.cs
@@ -10,9 +10,6 @@ namespace org.matheval.Node
     /// </summary>
     public class CallFuncNode : Implements.Node
     {
-        public static CallFuncNode ExternalFunction(string name, List<Implements.Node> args)
-            => new CallFuncNode(name, args, typeof(object), null, true);
-
         /// <summary>
         /// Function Name
         /// </summary>
@@ -29,11 +26,6 @@ namespace org.matheval.Node
         public List<Implements.Node> args;
 
         /// <summary>
-        /// Is this an external function?
-        /// </summary>
-        public bool IsExternal { get; }
-
-        /// <summary>
         /// Initializes a new instance structure to a specified
         /// 1. Function Name
         /// 2. List Value args
@@ -42,18 +34,11 @@ namespace org.matheval.Node
         /// <param name="funcName">funcName</param>
         /// <param name="args">args</param>
         /// <param name="returnType">returnType</param>
-        public CallFuncNode(string funcName, List<Implements.Node> args, Type returnType, IFunction excuter)
-            : this(funcName, args, returnType, excuter, false)
-        {
-        }
-
-        private CallFuncNode(string funcName, List<Implements.Node> args, Type returnType, IFunction excuter, bool isExternal)
-            : base(returnType)
+        public CallFuncNode(string funcName, List<Implements.Node> args,Type returnType, IFunction excuter) : base(returnType)
         {
             this.FuncName = funcName;
             this.args = args;
             this.Excuter = excuter;
-            IsExternal = isExternal;
         }
     }
 }

--- a/Math expression eval/org.matheval/Parser/Parser.cs
+++ b/Math expression eval/org.matheval/Parser/Parser.cs
@@ -40,7 +40,7 @@ namespace org.matheval
         /// Create object Lexer
         /// </summary>
         private Lexer Lexer;
-        
+
         /// <summary>
         /// Dc
         /// </summary>
@@ -355,9 +355,10 @@ namespace org.matheval
                 }
                 catch
                 {
-                    return CallFuncNode.ExternalFunction(identifierStr.ToUpperInvariant(), args);
+                    CallFuncNode callFuncNode = new CallFuncNode(identifierStr, args, typeof(object), null);
+                    return callFuncNode;
                 }
-                
+
                 List<FunctionDef> functionInfos = funcExecuter.GetInfo();
                 foreach (FunctionDef functionInfo in functionInfos)
                 {
@@ -474,9 +475,9 @@ namespace org.matheval
                 while (true)
                 {
                     IOperator iopNext = this.GetOperator();
-                    if (iopNext == null || 
+                    if (iopNext == null ||
                         !(iopCurr.GetPrec() < iopNext.GetPrec() ||
-                        (iopCurr.GetPrec() == iopNext.GetPrec() && 
+                        (iopCurr.GetPrec() == iopNext.GetPrec() &&
                         iopNext.GetAss() == Assoc.RIGHT)))
                     {
                         break;
@@ -670,7 +671,7 @@ namespace org.matheval
                     {
                         throw new Exception(Afe_Common.MSG_CASE_WRONG_PARAMS);
                     }
-                    this.Lexer.GetToken(); //eat )  				
+                    this.Lexer.GetToken(); //eat )
 
                     System.Type temp = varResultExprs[varResultExprs.Count - 1].ReturnType;
                     for (int i = 1; i < varResultExprs.Count - 1; i += 2)

--- a/Math expression eval/org.matheval/Parser/Parser.cs
+++ b/Math expression eval/org.matheval/Parser/Parser.cs
@@ -40,7 +40,7 @@ namespace org.matheval
         /// Create object Lexer
         /// </summary>
         private Lexer Lexer;
-
+        
         /// <summary>
         /// Dc
         /// </summary>
@@ -358,7 +358,7 @@ namespace org.matheval
                     CallFuncNode callFuncNode = new CallFuncNode(identifierStr, args, typeof(object), null);
                     return callFuncNode;
                 }
-
+                
                 List<FunctionDef> functionInfos = funcExecuter.GetInfo();
                 foreach (FunctionDef functionInfo in functionInfos)
                 {
@@ -475,9 +475,9 @@ namespace org.matheval
                 while (true)
                 {
                     IOperator iopNext = this.GetOperator();
-                    if (iopNext == null ||
+                    if (iopNext == null || 
                         !(iopCurr.GetPrec() < iopNext.GetPrec() ||
-                        (iopCurr.GetPrec() == iopNext.GetPrec() &&
+                        (iopCurr.GetPrec() == iopNext.GetPrec() && 
                         iopNext.GetAss() == Assoc.RIGHT)))
                     {
                         break;
@@ -671,7 +671,7 @@ namespace org.matheval
                     {
                         throw new Exception(Afe_Common.MSG_CASE_WRONG_PARAMS);
                     }
-                    this.Lexer.GetToken(); //eat )
+                    this.Lexer.GetToken(); //eat )                  
 
                     System.Type temp = varResultExprs[varResultExprs.Count - 1].ReturnType;
                     for (int i = 1; i < varResultExprs.Count - 1; i += 2)

--- a/Math expression eval/org.matheval/Parser/Parser.cs
+++ b/Math expression eval/org.matheval/Parser/Parser.cs
@@ -353,9 +353,9 @@ namespace org.matheval
                     }
                     funcExecuter = (IFunction)obj;
                 }
-                catch (Exception e)
+                catch
                 {
-                    throw new Exception(string.Format(Afe_Common.MSG_METH_NOTFOUND, new string[] { identifierStr.ToUpperInvariant() }));
+                    return CallFuncNode.ExternalFunction(identifierStr.ToUpperInvariant(), args);
                 }
                 
                 List<FunctionDef> functionInfos = funcExecuter.GetInfo();


### PR DESCRIPTION
Add a TryExternalFunction function method to the Expression object.
If a Function is not found internally, then this method is called so new functionality can be very easily added for specific usages.
the TryExternalFunction function is passed the name of the function plus the arguments and uses the Try pattern.

The unit tests show example usage by adding a "Range" function and a "Repeat" function.